### PR TITLE
ci: publish to npm via CircleCI OIDC trusted publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,14 @@ jobs:
             npm version patch -m "Bumped version to %s [ci skip]"
             git push -u origin ${CIRCLE_BRANCH} && git push --tags
       - run:
-          name: Publish to npm
-          command: npm publish
+          name: Upgrade npm (trusted publishing requires 11.5.1+)
+          command: sudo npm install -g npm@latest
+      - run:
+          name: Publish to npm via Trusted Publisher (OIDC)
+          command: |
+            rm ~/.npmrc
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npm publish
 
 workflows:
   version: 2


### PR DESCRIPTION
Switches publishing from NPM_TOKEN-based auth to npm Trusted Publishers (OIDC).

## Changes
- Adds a step to upgrade npm before publishing (trusted publishing requires npm 11.5.1+; cimg/node ships 10.x).
- Replaces the `npm publish` step with one that mints a short-lived OIDC token via `circleci run oidc get` and removes the legacy `~/.npmrc` fallback.
- `Setup NPM Token` step is left in place for `yarn install` read access; only the publish path changes.

## Blocked until
The npm-side Trusted Publisher entry must be configured for this package on npmjs.com before merging. The package's per-package config (org, repo, workflow, job) will be provided separately.

## Mirrors
Same pattern shipped to `serverless-spytec-config` master.
